### PR TITLE
Fixing the instructions to get the model list

### DIFF
--- a/cli/src/install/compose_db.rs
+++ b/cli/src/install/compose_db.rs
@@ -1,4 +1,5 @@
 use ceramic_config::convert_network_identifier;
+use ceramic_config::NetworkIdentifier;
 use std::path::Path;
 use tokio::io::AsyncWriteExt;
 
@@ -53,11 +54,12 @@ pub async fn install_compose_db(
     )
     .await?;
 
-    let network_name = if convert_network_identifier(&cfg.network.id) == "inmemory" {
-        "testnet-clay"
+    let network_id_for_model_list = if let NetworkIdentifier::InMemory = &cfg.network.id {
+        NetworkIdentifier::Clay
     } else {
-        &convert_network_identifier(&cfg.network.id)
+        cfg.network.id.clone()
     };
+    let network_name = convert_network_identifier(&network_id_for_model_list);
     
     log::info!(
         r#"

--- a/cli/src/install/compose_db.rs
+++ b/cli/src/install/compose_db.rs
@@ -53,11 +53,10 @@ pub async fn install_compose_db(
     )
     .await?;
 
-    let network_info_msg = if convert_network_identifier(&cfg.network.id) == "inmemory" {
-        String::from("")
+    let network_name = if convert_network_identifier(&cfg.network.id) == "inmemory" {
+        "testnet-clay"
     } else {
-        format!("\n\nTo list available models for usage, use\n\n    ./composedb model:list --network={} --table", 
-               convert_network_identifier(&cfg.network.id))
+        &convert_network_identifier(&cfg.network.id)
     };
     
     log::info!(
@@ -66,7 +65,11 @@ pub async fn install_compose_db(
     
     You can run composedb with
     
-        ./composedb{}
+        ./composedb
+    
+    To list available models for usage, use
+    
+        ./composedb model:list --network={} --table
     
     To run the graphiql server use
     
@@ -75,7 +78,7 @@ pub async fn install_compose_db(
     For more information on composedb and commands to run, see https://composedb.js.org/docs/0.4.x/first-composite
     
     You can also take a look at https://github.com/ceramicstudio/EthDenver2023Demo for more ideas on using ComposeDB."#,
-        network_info_msg
+        network_name
     );
 
     Ok(())

--- a/cli/src/install/compose_db.rs
+++ b/cli/src/install/compose_db.rs
@@ -53,27 +53,29 @@ pub async fn install_compose_db(
     )
     .await?;
 
+    let network_info_msg = if convert_network_identifier(&cfg.network.id) == "inmemory" {
+        String::from("")
+    } else {
+        format!("\n\nTo list available models for usage, use\n\n    ./composedb model:list --network={} --table", 
+               convert_network_identifier(&cfg.network.id))
+    };
+    
     log::info!(
         r#"
-ComposeDB cli now available.
-
-You can run composedb with
-
-    ./composedb
-
-To list available models for usage, use
-
-    ./composedb model:list --network={} --table
-
-To run the graphiql server use
-
-    ./composedb graphql:server --graphiql --port 5005 <path to compiled composite>
+    ComposeDB cli now available.
     
-For more information on composedb and commands to run, see https://composedb.js.org/docs/0.4.x/first-composite
-
-You can also take a look at https://github.com/ceramicstudio/EthDenver2023Demo for more ideas on using ComposeDB.
-        "#,
-        convert_network_identifier(&cfg.network.id)
+    You can run composedb with
+    
+        ./composedb{}
+    
+    To run the graphiql server use
+    
+        ./composedb graphql:server --graphiql --port 5005 <path to compiled composite>
+        
+    For more information on composedb and commands to run, see https://composedb.js.org/docs/0.4.x/first-composite
+    
+    You can also take a look at https://github.com/ceramicstudio/EthDenver2023Demo for more ideas on using ComposeDB."#,
+        network_info_msg
     );
 
     Ok(())


### PR DESCRIPTION
During the DX testing round developers pointed out that when they run wheel `inmemory`, they get wrong instructions for accessing the model list:

` ./composedb model:list --network=inmemory --table`

This throws an error because `inmemory` is a wrong flag there. This PR suggests to allow developers to get a list of models by using `testnet-clay` flag instead.