### PR TITLE
Dont use npm global installs for ceramic

### DIFF
--- a/cli/src/install/ceramic_daemon.rs
+++ b/cli/src/install/ceramic_daemon.rs
@@ -39,7 +39,7 @@ pub async fn install_ceramic_daemon(
     if let Some(v) = version.as_ref() {
         program.push_str(&format!("@{}", v.to_string()));
     }
-    npm_install_package(&working_directory, &program, true).await?;
+    npm_install_package(&working_directory, &program, false).await?;
 
     let ans = match start_ceramic {
         Some(true) => true,
@@ -138,7 +138,7 @@ pub async fn install_ceramic_daemon(
 
     log::info!(
         r#"
-When you would like to run ceramic please run 
+When you would like to run ceramic please run
 
     ./ceramic daemon --config {}
 

--- a/cli/src/install/compose_db.rs
+++ b/cli/src/install/compose_db.rs
@@ -30,7 +30,7 @@ pub async fn install_compose_db(
     if let Some(v) = version.as_ref() {
         program.push_str(&format!("@{}", v.to_string()));
     }
-    npm_install_package(working_directory, &program, true).await?;
+    npm_install_package(working_directory, &program, false).await?;
 
     let env_file = working_directory.join("composedb.env");
     let mut f = tokio::fs::OpenOptions::new()
@@ -64,21 +64,21 @@ pub async fn install_compose_db(
     log::info!(
         r#"
     ComposeDB cli now available.
-    
+
     You can run composedb with
-    
+
         ./composedb
-    
+
     To list available models for usage, use
-    
+
         ./composedb model:list --network={} --table
-    
+
     To run the graphiql server use
-    
+
         ./composedb graphql:server --graphiql --port 5005 <path to compiled composite>
-        
+
     For more information on composedb and commands to run, see https://composedb.js.org/docs/0.4.x/first-composite
-    
+
     You can also take a look at https://github.com/ceramicstudio/EthDenver2023Demo for more ideas on using ComposeDB."#,
         network_name
     );


### PR DESCRIPTION
Startup fails when running `wheel quiet generate` due to an incorrect path to the ceramic install.

This PR keep all modules local and works fine for me.

If we want to globally install the packages, I think there should be an explicit flag as we're making changes to the system outside the working directory.
