### PR TITLE
feat: Adjustments to defaults, postgres docker example, minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@
 Cargo.lock
 tmp
 .DS_Store
+# default wheel app names (historic and current)
 ceramic-test-app
+ceramic-app
+# postgres compose volume
+ceramic-pg-data

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Please follow the instructions that follow.
 
 Setup Ceramic and ComposeDB in a quick and easy fashion
 
-Wheel can handle "default" behavior for Ceramic and ComposeDB based on your network, or you can customize your 
-configuration by stepping through some or all the available configuration options.
+Wheel can handle "default" behavior for Ceramic and ComposeDB based on your network, or you can customize your configuration by stepping through some or all the available configuration options.
 
 ![](./gifs/running.gif)
 
@@ -35,8 +34,9 @@ If you don't want to step through prompts at all, you can use wheel in "quiet" m
 This requires you to have already setup a DID and [CAS Auth](#cas-auth). Please run `wheel --help` for more options.
 
 ### CAS Auth
+
 All networks other than InMemory require CAS authorization. Wheel will walk you through setting up CAS authorization, but
-for more information see https://composedb.js.org/docs/0.4.x/guides/composedb-server/access-mainnet#step-1-start-your-node-and-copy-your-key-did.
+for more information read about [starting your node and copying your DID](https://composedb.js.org/docs/0.4.x/guides/composedb-server/access-mainnet#step-1-start-your-node-and-copy-your-key-did).
 
 ## Setting up Postgres
 If using Postgres, it will need to be setup. Visit https://www.postgresql.org/download/ to install postgres.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ All networks other than InMemory require CAS authorization. Wheel will walk you 
 for more information read about [starting your node and copying your DID](https://composedb.js.org/docs/0.4.x/guides/composedb-server/access-mainnet#step-1-start-your-node-and-copy-your-key-did).
 
 ## Setting up Postgres
-If using Postgres, it will need to be setup. Visit https://www.postgresql.org/download/ to install postgres.
+
+If using Postgres, it will need to be setup. *Note*: For production ceramic nodes, only postgres is supported.
+
+### Option 1: Local Install
+
+Visit <https://www.postgresql.org/download/> to install postgres locally.
 
 You will then need to configure postgres for ceramic.
 
@@ -53,4 +58,16 @@ You will then need to configure postgres for ceramic.
 
 The connection string you provide to wheel will then be `postgres://ceramic:password@127.0.0.1:5432/ceramic`
 
-*Note*: For production ceramic nodes, only postgres is supported. 
+### Option 2: Using Docker
+
+For local development and testing, you can run a postgres in docker rather than installing a postgres server locally. The wheel defaults are to use sqlite, however, this is an option if you want to verify postgres indexing. It is not recommended to run a production node this way! This requires having [Docker](https://docs.docker.com/engine/install/) and [Docker compose](https://docs.docker.com/compose/install/) installed. You can read more about the [official Postgres image](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/).
+
+Copy the [compose.yaml](https://github.com/ceramicstudio/wheel/blob/main/compose.yaml) file to your computer. You are welcome to change the values, but by default the connection string for wheel will be `postgres://ceramic:password@127.0.0.1:5432/ceramic`. Start the container:
+
+    docker compose up -d
+
+To stop it
+
+    docker compose down # include -v to delete the data
+
+Postgres data will be stored in the `./ceramic-data` folder using a docker volume.

--- a/cli/src/install/ceramic_daemon.rs
+++ b/cli/src/install/ceramic_daemon.rs
@@ -39,7 +39,7 @@ pub async fn install_ceramic_daemon(
     if let Some(v) = version.as_ref() {
         program.push_str(&format!("@{}", v.to_string()));
     }
-    npm_install_package(&working_directory, &program, true).await?;
+    npm_install_package(&working_directory, &program, false).await?;
 
     let ans = match start_ceramic {
         Some(true) => true,

--- a/cli/src/install/compose_db.rs
+++ b/cli/src/install/compose_db.rs
@@ -30,7 +30,7 @@ pub async fn install_compose_db(
     if let Some(v) = version.as_ref() {
         program.push_str(&format!("@{}", v.to_string()));
     }
-    npm_install_package(working_directory, &program, true).await?;
+    npm_install_package(working_directory, &program, false).await?;
 
     let env_file = working_directory.join("composedb.env");
     let mut f = tokio::fs::OpenOptions::new()

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -156,6 +156,7 @@ Selection is used to setup project defaults"#)
     let with_app_template = if with_composedb {
         Confirm::new("Include ComposeDB Sample Application?")
             .with_help_message("Installs a sample application using ComposeDB")
+            // different than non-interactive defaults, but this user is more likely to have an app
             .with_default(false)
             .prompt()?
     } else {

--- a/cli/src/prompt/ceramic_advanced_config.rs
+++ b/cli/src/prompt/ceramic_advanced_config.rs
@@ -149,7 +149,7 @@ fn configure_network(cfg: &mut Config) -> anyhow::Result<()> {
 pub fn configure_node(cfg: &mut Config) -> anyhow::Result<()> {
     let gateway = Confirm::new("Run as gateway?")
         .with_help_message("Gateway nodes cannot perform mutations")
-        .with_default(true)
+        .with_default(false)
         .prompt()?;
     cfg.node.gateway = gateway;
     Ok(())

--- a/cli/src/prompt/project.rs
+++ b/cli/src/prompt/project.rs
@@ -8,7 +8,7 @@ pub struct Project {
 
 pub async fn configure_project(working_directory: impl AsRef<Path>) -> anyhow::Result<Project> {
     let project_name = Text::new("Project Name")
-        .with_default("ceramic-test-app")
+        .with_default("ceramic-app")
         .prompt()?;
     let project_path = working_directory.as_ref().join(&project_name);
     let project_path = Text::new("Project Path")

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,15 @@
+version: '3.1'
+
+services:
+  db:
+    image: postgres:16
+    container_name: ceramic-db
+    restart: always
+    environment:
+      POSTGRES_USER: ceramic
+      POSTGRES_PASSWORD: password
+      DATABASE: ceramic
+    volumes:
+      - ./ceramic-pg-data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432


### PR DESCRIPTION
While experimenting, I noticed a few minor things and made some adjustments.

- Some defaults were different when choosing advanced config as opposed to accepting all defaults. Adjusted these to align more closely when it made sense. For example, running a gateway node and the default app name.
-There was a bug installing a test app when the branch had a slash in the name, this has been fixed. 
- I added information (and a compose file) for running postgres in docker rather than installing the server locally. I modified my config to use it for my `inmemory` network and it seemed to work okay. 
- Remove `npm install -g`. Installing globally doesn't work with how the daemon start is currently implemented. Rather than fix that, prefer a local install as we don't need a global install. The test app brings its own node_modules folders and scripts to run ceramic/composedb, and this makes it easier to compare multiple versions in different folders.

I made some [changes to the test app](https://github.com/ceramicstudio/ComposeDbExampleApp/pull/26) which is how I noticed the branch issue.