### PR TITLE
feat: ctrl+c/sigint handling and working directory override fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ by option.
 
 If you don't want to step through prompts at all, you can use wheel in "quiet" mode, which will default to clay
 
-    wheel --working-directory <path to setup your work in> quiet  --network <one of inmemory|local|dev|clay|mainnet> --did <did> --pk <pk>
+    wheel --working-directory <path to setup your work in> quiet  --network <one of in-memory|local|dev|clay|mainnet> generate 
 
-This requires you to have already setup a DID and [CAS Auth](#cas-auth). Please run `wheel --help` for more options.
+You can also pass an existing DID and PK via the `specify` option instead of `generate`. This requires you to have already setup a DID and [CAS Auth](#cas-auth). Please run `wheel --help` for more options.
 
 ### CAS Auth
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ serde_json.workspace = true
 spinners = "4.1"
 sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "sqlite"] }
 ssi = "0.7"
-tokio = { version = "1.25", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread"] }
+tokio = { version = "1.25", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal"] }
 which = "4.4"
 zip = "0.6"
 

--- a/cli/src/install/ceramic_daemon.rs
+++ b/cli/src/install/ceramic_daemon.rs
@@ -83,7 +83,7 @@ pub async fn install_ceramic_daemon(
             if let Ok(exit) = process.wait().await {
                 let _ = tx.send(exit.clone()).await;
                 log::info!(
-                    "Ceramic exited with code {}",
+                    "\nCeramic exited with code {}",
                     exit.code().unwrap_or_else(|| 0)
                 );
                 if !exit.success() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -108,6 +108,13 @@ async fn main() -> anyhow::Result<()> {
     let working_directory = args
         .working_directory
         .map(PathBuf::from)
+        .and_then(|p| {
+            if p.is_absolute() {
+                Some(p)
+            } else {
+                Some(current_directory.join(p))
+            }
+        })
         .unwrap_or_else(|| current_directory);
     let mut versions = wheel_3box::Versions::default();
     if let Some(ref v) = args.ceramic_version {


### PR DESCRIPTION
I added `ctrl+c` exit handling and made some small adjustments to running in quiet mode. Fixes [issue 9](https://github.com/ceramicstudio/wheel/issues/9)

Now, we give up waiting for our futures and exit on `ctrl+c`. On a second `ctrl+c`, we give up waiting for a graceful shutdown and abort the task completely. It's possible that something is still blocking and won't yield when we request cancellation, so we may need to listen to the channel at a lower level, but for now, the top level should be sufficient. All of our tasks should be repeatable, so if we abort and re-run wheel, it should succeed or it's a bug.

Also, when a custom directory is specified, we make sure it is absolute. Before this, it was possible to fail to run the ceramic daemon as the start up script would reference a relative directory and fail to start.